### PR TITLE
hardcode version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,12 @@ README = README()  # NOQA
 
 
 setup(
-      use_scm_version={
-          'write_to': 'src/dateutil/_version.py',
-      },
+      #use_scm_version={
+      #    'write_to': 'src/dateutil/_version.py',
+      #},
+      # NOTE: different from upstream - version is hardcoded so that the
+      # package can be fetched as a ZIP archive by pip
+      version='2.8.2+close',
       ## Needed since doctest not supported by PyPA.
       long_description = README,
       cmdclass={


### PR DESCRIPTION
When trying to include dateutil as a ZIP dependency so that it can be hashed, pip fails with the following:

```
        LookupError: setuptools-scm was unable to detect version for /tmp/pip-resolver-d1euh6pe/python-dateutil.

        Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
```

This PR hardcodes a close-specific version and removes reliance on `use_scm_version`.